### PR TITLE
Pass signatures with add claimant request

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -4,6 +4,7 @@
 # for this project installed.
 set -e
 
+ENGINE_HOST="${ENGINE_HOST:-127.0.0.1}"
 ENGINE_PORT="${ENGINE_PORT:-7191}"
 
-uvicorn --port "$ENGINE_PORT" --host 127.0.0.1 --workers 2 engineapi.api:app
+uvicorn --port "$ENGINE_PORT" --host "$ENGINE_HOST" --workers 2 engineapi.api:app

--- a/engineapi/data.py
+++ b/engineapi/data.py
@@ -74,11 +74,25 @@ class DropCreatedResponse(BaseModel):
 
 
 class Claimant(BaseModel):
-    address: str
+    """
+    Represents a claimant with allowed amount to claim and block deadline.
+    """
+
+    address: str = Field(alias="claimant_address")
     amount: int
+    signature: Optional[str] = None
+    claim_block_deadline: Optional[int] = None
+    claim_id: Optional[int] = None
+
+    class Config:
+        allow_population_by_field_name = True
 
 
 class DropAddClaimantsRequest(BaseModel):
+    """
+    Whitelist of claimants for claim.
+    """
+
     dropper_claim_id: UUID
     claimants: List[Claimant] = Field(default_factory=list)
 

--- a/engineapi/routes/dropper.py
+++ b/engineapi/routes/dropper.py
@@ -701,7 +701,9 @@ async def add_claimants(
     db_session: Session = Depends(db.yield_db_session),
 ) -> data.ClaimantsResponse:
     """
-    Add addresses to particular claim
+    Add whitelisted claimants to particular claim.
+    If no signature provided for claimant, it will overwrite existing one
+    with NULL at database.
     """
 
     try:


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

Existing request to add new claimants:

```json
{
    "dropper_claim_id": "<uuid>",
    "claimants": [
        {
            "address": "<0x00..>",
            "amount": 100
        }
    ]
}
```

New format:

```json
{
    "dropper_claim_id": "<uuid>",
    "claimants": [
        {
            "claimant_address": "<0x00..>",
            "amount": 100,
            "signature": "<0x00..>",
            "claim_block_deadline": 36463140,
            "claim_id": 1
        }
    ]
}
```

If empty signature provided and database contains claimant signatures it will be updated with NULL value.

## How to test these changes?

Tested locally. Saved previous behaviour, Changed only response `address`  to `claimant_address`.

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
