### PR TITLE
Updated "waggle sign dropper pull" to take a search query

### DIFF
--- a/waggle/bugout.go
+++ b/waggle/bugout.go
@@ -55,7 +55,6 @@ func WriteCursorToJournal(client *bugout.BugoutClient, token, journalID, cursorN
 
 func ReportsIterator(client *bugout.BugoutClient, token, journalID, cursor, queryTerms string, limit, offset int) (spire.EntryResultsPage, error) {
 	var query string = fmt.Sprintf("!tag:type:cursor %s", queryTerms)
-	fmt.Println(query)
 	if cursor != "" {
 		cleanedCursor := CleanTimestamp(cursor)
 		query = fmt.Sprintf("%s created_at:>%s", query, cleanedCursor)

--- a/waggle/bugout.go
+++ b/waggle/bugout.go
@@ -36,7 +36,7 @@ func GetCursorFromJournal(client *bugout.BugoutClient, token, journalID, cursorN
 	return results.Results[0].ContextUrl, nil
 }
 
-func WriteCursorToJournal(client *bugout.BugoutClient, token, journalID, cursorName, cursor string) error {
+func WriteCursorToJournal(client *bugout.BugoutClient, token, journalID, cursorName, cursor, queryTerms string) error {
 	title := fmt.Sprintf("waggle cursor: %s", cursorName)
 	entryContext := spire.EntryContext{
 		ContextType: "waggle",
@@ -48,12 +48,14 @@ func WriteCursorToJournal(client *bugout.BugoutClient, token, journalID, cursorN
 		fmt.Sprintf("cursor:%s", cursorName),
 		fmt.Sprintf("waggle_version:%s", WAGGLE_VERSION),
 	}
-	_, err := client.Spire.CreateEntry(token, journalID, title, cursor, tags, entryContext)
+	content := fmt.Sprintf("Cursor: %s at %s\nQuery: %s", cursorName, cursor, queryTerms)
+	_, err := client.Spire.CreateEntry(token, journalID, title, content, tags, entryContext)
 	return err
 }
 
-func ReportsIterator(client *bugout.BugoutClient, token, journalID, cursor string, limit, offset int) (spire.EntryResultsPage, error) {
-	var query string = "!tag:type:cursor"
+func ReportsIterator(client *bugout.BugoutClient, token, journalID, cursor, queryTerms string, limit, offset int) (spire.EntryResultsPage, error) {
+	var query string = fmt.Sprintf("!tag:type:cursor %s", queryTerms)
+	fmt.Println(query)
 	if cursor != "" {
 		cleanedCursor := CleanTimestamp(cursor)
 		query = fmt.Sprintf("%s created_at:>%s", query, cleanedCursor)
@@ -108,13 +110,13 @@ func DropperReportsToCSV(reports []DropperClaimMessage, header bool, w io.Writer
 	return csvWriter.WriteAll(records)
 }
 
-func ProcessDropperClaims(client *bugout.BugoutClient, bugoutToken, journalID, cursorName string, batchSize int, header bool, w io.Writer) error {
+func ProcessDropperClaims(client *bugout.BugoutClient, bugoutToken, journalID, cursorName, query string, batchSize int, header bool, w io.Writer) error {
 	cursor, cursorErr := GetCursorFromJournal(client, bugoutToken, journalID, cursorName)
 	if cursorErr != nil {
 		return cursorErr
 	}
 
-	searchResults, searchErr := ReportsIterator(client, bugoutToken, journalID, cursor, batchSize, 0)
+	searchResults, searchErr := ReportsIterator(client, bugoutToken, journalID, cursor, query, batchSize, 0)
 	if searchErr != nil {
 		return searchErr
 	}
@@ -131,7 +133,7 @@ func ProcessDropperClaims(client *bugout.BugoutClient, bugoutToken, journalID, c
 
 	var processedErr error
 	if len(searchResults.Results) > 0 {
-		processedErr = WriteCursorToJournal(client, bugoutToken, journalID, cursorName, searchResults.Results[len(searchResults.Results)-1].CreatedAt)
+		processedErr = WriteCursorToJournal(client, bugoutToken, journalID, cursorName, searchResults.Results[len(searchResults.Results)-1].CreatedAt, query)
 	}
 
 	return processedErr

--- a/waggle/cmd.go
+++ b/waggle/cmd.go
@@ -197,14 +197,19 @@ func CreateSignCommand() *cobra.Command {
 		Use:   "single",
 		Short: "Sign a single claim method call",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			key, keyErr := KeyFromFile(keyfile, password)
-			if keyErr != nil {
-				return keyErr
-			}
-
 			messageHash, hashErr := DropperClaimMessageHash(chainId, dropperAddress, dropId, requestId, claimant, blockDeadline, amount)
 			if hashErr != nil {
 				return hashErr
+			}
+
+			if header {
+				cmd.Println(hex.EncodeToString(messageHash))
+				return nil
+			}
+
+			key, keyErr := KeyFromFile(keyfile, password)
+			if keyErr != nil {
+				return keyErr
 			}
 
 			signedMessage, err := SignRawMessage(messageHash, key, sensible)
@@ -236,6 +241,7 @@ func CreateSignCommand() *cobra.Command {
 	dropperSingleSubcommand.Flags().StringVar(&claimant, "claimant", "", "Address of the intended claimant.")
 	dropperSingleSubcommand.Flags().StringVar(&blockDeadline, "block-deadline", "0", "Block number by which the claim must be made.")
 	dropperSingleSubcommand.Flags().StringVar(&amount, "amount", "0", "Amount of tokens to distribute.")
+	dropperSingleSubcommand.Flags().BoolVar(&header, "hash", false, "Output the message hash instead of the signature.")
 
 	dropperBatchSubcommand := &cobra.Command{
 		Use:   "batch",

--- a/waggle/cmd.go
+++ b/waggle/cmd.go
@@ -140,7 +140,7 @@ func CreateSignCommand() *cobra.Command {
 	// All variables to be used for arguments.
 	var chainId int64
 	var batchSize int
-	var bugoutToken, cursorName, journalID, keyfile, password, claimant, dropperAddress, dropId, requestId, blockDeadline, amount, infile, outfile string
+	var bugoutToken, cursorName, journalID, keyfile, password, claimant, dropperAddress, dropId, requestId, blockDeadline, amount, infile, outfile, query string
 	var sensible, header, isCSV bool
 
 	signCommand.PersistentFlags().StringVarP(&keyfile, "keystore", "k", "", "Path to keystore file (this should be a JSON file).")
@@ -363,12 +363,13 @@ func CreateSignCommand() *cobra.Command {
 				return errors.New("please specify a Bugout journal ID, by passing it as the --journal/-j argument")
 			}
 
-			return ProcessDropperClaims(&bugoutClient, bugoutToken, journalID, cursorName, batchSize, header, os.Stdout)
+			return ProcessDropperClaims(&bugoutClient, bugoutToken, journalID, cursorName, query, batchSize, header, os.Stdout)
 		},
 	}
 	dropperPullSubcommand.Flags().StringVarP(&bugoutToken, "token", "t", "", "Bugout API access token. If you don't have one, you can generate one at https://bugout.dev/account/tokens.")
 	dropperPullSubcommand.Flags().StringVarP(&journalID, "journal", "j", "", "ID of Bugout journal from which to pull claim requests.")
 	dropperPullSubcommand.Flags().StringVarP(&cursorName, "cursor", "c", "", "Name of cursor which defines which requests are processed and which ones are not.")
+	dropperPullSubcommand.Flags().StringVarP(&query, "query", "q", "", "Additional Bugout search query to apply in Bugout.")
 	dropperPullSubcommand.Flags().IntVarP(&batchSize, "batch-size", "N", 500, "Maximum number of messages to process.")
 	dropperPullSubcommand.Flags().BoolVarP(&header, "header", "H", true, "Set this flag to include header row in output CSV.")
 

--- a/waggle/version.go
+++ b/waggle/version.go
@@ -1,3 +1,3 @@
 package main
 
-var WAGGLE_VERSION string = "0.0.3"
+var WAGGLE_VERSION string = "0.0.4"


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

Added the `-q/--query` argument to `waggle sign dropper pull`. This is optional and can be used to further filter requests stored in a Bugout journal.

For example, using `tag:chainId:<chain ID>`.

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

Tested manually against live drops.

<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
