### PR TITLE
Removed `adminTerminusInfo` from `IInventory`

### DIFF
--- a/contracts/interfaces/IInventory.sol
+++ b/contracts/interfaces/IInventory.sol
@@ -14,7 +14,7 @@ struct EquippedItem {
     uint256 Amount;
 }
 
-// Interface ID: 6e34096c
+// Interface ID: c8a97a5b
 //
 // Calculated by solface: https://github.com/moonstream-to/solface
 //
@@ -60,8 +60,6 @@ interface IInventory {
         uint256 amount,
         address unequippedBy
     );
-
-    function adminTerminusInfo() external view returns (address, uint256);
 
     function subject() external view returns (address);
 

--- a/contracts/inventory/InventoryFacet.sol
+++ b/contracts/inventory/InventoryFacet.sol
@@ -14,7 +14,7 @@ import "@openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin-contracts/contracts/token/ERC1155/IERC1155.sol";
 import "../diamond/libraries/LibDiamond.sol";
 import {DiamondReentrancyGuard} from "../diamond/security/DiamondReentrancyGuard.sol";
-import {Slot, EquippedItem, IInventory} from "./IInventory.sol";
+import {Slot, EquippedItem, IInventory} from "../interfaces/IInventory.sol";
 import {TerminusPermissions} from "../terminus/TerminusPermissions.sol";
 
 /**


### PR DESCRIPTION
Access control should not be a concern of the Inventory interface. That is up to each Inventory implementation to define.